### PR TITLE
Add deploy script and move-1 compliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,7 @@ cd scaffold-move
 yarn install
 ```
 
-2. Run a local network in  the first terminal:
-
-```
-yarn chain
-```
-
-**If you are deploying to devnet or testnet, you can skip this step.**
-
-3. On a second terminal, initialize a new account.
+2. THen, initialize a new account.
 
 ```
 yarn account
@@ -60,7 +52,9 @@ yarn account
 
 This command overwrites `packages/move/.aptos/config.yaml` with a new Aptos account. The new address is copied over to the first address in the Move.toml file. If no address exists in this file, it is added on a new line.
 
-4. Deploy the test modules:
+Use the `--network` tag to define a network to create the account on. Alternatively, you can change the `defaultNetwork` value in `packages/move/move.config.js`.
+
+3. Deploy the test modules:
 
 ```
 yarn deploy
@@ -68,7 +62,7 @@ yarn deploy
 
 This command deploys the move modules to the selected network. The modules are located in `packages/move/sources` and can be modified to suit your needs. The `yarn deploy` command uses `aptos move publish` to publish the modules to the network. After this is executes the script located in `scripts/loadModules.js` to make the new modules available in the nextjs frontend.
 
-5. On a third terminal, start your NextJS app:
+4. On a second terminal, start your NextJS app:
 
 ```
 yarn start
@@ -110,6 +104,7 @@ Your input is valuable! If you have suggestions or want to contribute, we encour
 None of this would have been possible without the great work done in:
 - [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2)
 - [Aptos Explorer](https://github.com/aptos-labs/explorer)
+- [Aptos Wallet Adapter](https://github.com/aptos-labs/aptos-wallet-adapter)
 
 ## Built by
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "scripts": {
     "account": "yarn workspace @scaffold-move/move account",
     "chain": "yarn workspace @scaffold-move/move chain",
-    "deploy": "yarn workspace @scaffold-move/move publish",
-    "publish": "yarn workspace @scaffold-move/move publish",
+    "deploy": "yarn workspace @scaffold-move/move deploy",
     "compile": "yarn workspace @scaffold-move/move compile",
     "test": "yarn workspace @scaffold-move/move test",
     "format": "yarn next:format && yarn workspace @scaffold-move/move format",

--- a/packages/move/Move.toml
+++ b/packages/move/Move.toml
@@ -2,8 +2,8 @@
 name = 'onchain_bio'
 version = '1.0.0'
 [dependencies.AptosFramework]
-git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'main'
-subdir = 'aptos-move/framework/aptos-framework'                                                                                                                                                                                            
+git = "https://github.com/movementlabsxyz/aptos-core.git"
+rev = "movement"
+subdir = "aptos-move/framework/aptos-framework"
 [addresses]
-deployment_addr='0xf6f67805e60b18ee9ced00c3f71e030b2487af5480610e9324dd14d6f6b92690'
+deployment_addr='_'

--- a/packages/move/move.config.js
+++ b/packages/move/move.config.js
@@ -3,10 +3,6 @@ const defaultNetwork = 'movement_testnet';
 // const overrideMoveVersion = 'move-1'; // Uncomment to use Move-1 for all networks
 
 const networks = {
-  movement_devnet: {
-    'rest-url': 'https://devnet.m1.movementlabs.xyz/',
-    'faucet-url': 'https://devnet.m1.movementlabs.xyz/',
-  },
   movement_testnet: {
     "rest-url": "https://aptos.testnet.bardock.movementlabs.xyz/v1",
     // "faucet-url": "https://faucet.testnet.bardock.movementnetwork.xyz/",

--- a/packages/move/move.config.js
+++ b/packages/move/move.config.js
@@ -1,5 +1,6 @@
 
-const defaultNetwork = 'testnet';
+const defaultNetwork = 'movement_testnet';
+// const overrideMoveVersion = 'move-1'; // Uncomment to use Move-1 for all networks
 
 const networks = {
   movement_devnet: {
@@ -7,20 +8,12 @@ const networks = {
     'faucet-url': 'https://devnet.m1.movementlabs.xyz/',
   },
   movement_testnet: {
-    "rest-url": "https://aptos.testnet.porto.movementlabs.xyz/v1"
-  },
-  // Old testnet for reference
-  suzuka_testnet: {
-    "rest-url": "https://aptos.testnet.suzuka.movementlabs.xyz/v1"
-  },
-  bardock_testnet: {
     "rest-url": "https://aptos.testnet.bardock.movementlabs.xyz/v1",
     // "faucet-url": "https://faucet.testnet.bardock.movementnetwork.xyz/",
   },
   movement_mainnet: {
     "rest-url": "https://mainnet.movementnetwork.xyz/v1"
   },
-  // Add any other networks you need here
 };
 
 // Set to false if external modules should not be loaded via script.

--- a/packages/move/package.json
+++ b/packages/move/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "account": "node scripts/init-account.js",
     "chain": "aptos node run-local-testnet",
-    "deploy": "aptos move publish --assume-yes && node scripts/loadModules.js",
-    "publish": "aptos move publish --assume-yes && node scripts/loadModules.js",
+    "deploy": "node scripts/deploy.js && node scripts/loadModules.js",
     "compile": "aptos move compile",
     "test": "aptos move test",
     "format": "aptos move fmt",

--- a/packages/move/scripts/deploy.js
+++ b/packages/move/scripts/deploy.js
@@ -19,7 +19,6 @@ async function main() {
   const configPath = path.join(__dirname, '../.aptos/config.yaml');
   const config = parseYaml(configPath);
   const network = config.profiles.default.network;
-  const faucetUrl = config.profiles.default.faucet_url;
 
   // Determine if network is custom (localhost or custom URL)
   const isCustomNetwork = network.includes('Custom');

--- a/packages/move/scripts/deploy.js
+++ b/packages/move/scripts/deploy.js
@@ -1,0 +1,56 @@
+const { execSync } = require('child_process');
+const yaml = require('js-yaml');
+const fs = require('fs');
+const path = require('path');
+const minimist = require('minimist');
+const { overrideMoveVersion } = require('../move.config.js');
+
+
+function parseYaml(filePath) {
+  const yamlContent = fs.readFileSync(filePath, 'utf-8');
+  return yaml.load(yamlContent);
+}
+
+async function main() {
+  // Parse command line arguments
+  const argv = minimist(process.argv.slice(2));
+
+  // Read config to check network
+  const configPath = path.join(__dirname, '../.aptos/config.yaml');
+  const config = parseYaml(configPath);
+  const network = config.profiles.default.network;
+  const faucetUrl = config.profiles.default.faucet_url;
+
+  // Determine if network is custom (localhost or custom URL)
+  const isCustomNetwork = network.includes('Custom');
+
+  // Build deploy command
+  let deployCommand = 'aptos move publish';
+  if (isCustomNetwork) {
+    // Default to move-1 and bytecode-version 6 for custom networks, needed for deployment to Movement Bardock Testnet
+    deployCommand += ' --move-1 --bytecode-version 6';
+  } else if (overrideMoveVersion) {
+    if (overrideMoveVersion === 'move-1') {
+      deployCommand += ' --move-1';
+    } else if (overrideMoveVersion === 'move-2') {
+      deployCommand += ' --move-2';
+    } else {
+      throw new Error(`Invalid move version: ${overrideMoveVersion}`);
+    }
+  }
+
+  // Add assume-yes flag
+  deployCommand += ' --assume-yes';
+
+  try {
+    // Execute deploy command
+    console.log(`Executing: ${deployCommand}`);
+    execSync(deployCommand, { stdio: 'inherit' });
+
+  } catch (error) {
+    console.error('Deployment failed:', error.message);
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/packages/move/scripts/init-account.js
+++ b/packages/move/scripts/init-account.js
@@ -3,7 +3,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { exec } = require('child_process');
 const minimist = require('minimist');
-const { defaultNetwork, networks } = require('../move.config.ts'); // Import from move.config.ts
+const { defaultNetwork, networks } = require('../move.config.js');
 
 const args = minimist(process.argv.slice(2));
 const network = args.network || defaultNetwork; // Use default network from config
@@ -29,7 +29,7 @@ function updateMoveTomlAddress(tomlPath, newAddress) {
     if (addressesContent) {
       const firstAddressLine = addressesContent.split('\n')[0];
       const firstAddressKey = firstAddressLine.split('=')[0].trim();
-      
+
       // Remove the current first address line
       const newAddressesContent = addressesContent.replace(firstAddressLine, `${firstAddressKey}='${newAddress}'`);
       toml = toml.replace(addressesMatch[1], `\n${newAddressesContent}\n`);
@@ -60,6 +60,11 @@ function initCustomNetwork(restUrl, faucetUrl) {
     }
     console.log(`Custom network initialized successfully.`);
     updateMoveTomlAfterInit();
+     // For Movement testnet, prompt user to get tokens from the faucet
+    if (network === 'movement_testnet') {
+      console.log('\nTo get test tokens for Movement Testnet, visit:');
+      console.log('https://faucet.movementnetwork.xyz/?network=bardock');
+    }
   });
 }
 

--- a/packages/move/scripts/loadModules.js
+++ b/packages/move/scripts/loadModules.js
@@ -3,7 +3,7 @@ const path = require('path');
 const yaml = require('js-yaml');
 const { AptosClient } = require('aptos'); // Assuming you're using the Aptos SDK for JavaScript
 const axios = require('axios'); // Add axios to make HTTP requests
-const { loadExternalModules } = require('../move.config.ts'); // Import from move.config.ts
+const { loadExternalModules } = require('../move.config.js');
 const deploymentsDir = path.join(__dirname, '../deployments');
 
 // Paths to the relevant files

--- a/packages/nextjs/app/bio/page.tsx
+++ b/packages/nextjs/app/bio/page.tsx
@@ -52,11 +52,8 @@ const OnchainBio: NextPage = () => {
 
     try {
       await refetchBio();
-      console;
       if (bioResource) {
         setAccountHasBio(true);
-
-        // TODO: Fix this workaround
         setCurrentName(bioResource.name);
         setCurrentBio(bioResource.bio);
       } else {

--- a/packages/nextjs/app/debug/_components/DebugModules.tsx
+++ b/packages/nextjs/app/debug/_components/DebugModules.tsx
@@ -46,7 +46,6 @@ export function DebugModules() {
                   onClick={() => setSelectedModule(moduleName)}
                 >
                   {moduleName as string}
-                  {/* TODO: fix this below */}
                   {(modulesData[moduleName] as GenericModule).external && (
                     <span className="tooltip tooltip-top tooltip-accent" data-tip="External module">
                       <BarsArrowUpIcon className="h-4 w-4 cursor-pointer" />

--- a/packages/nextjs/app/debug/_components/module/WriteFunctionForm.tsx
+++ b/packages/nextjs/app/debug/_components/module/WriteFunctionForm.tsx
@@ -14,6 +14,7 @@ import {
   ModuleName,
   MoveFunction,
 } from "~~/utils/scaffold-move/module";
+import { getBlockExplorerTxLink } from "~~/utils/scaffold-move/networks";
 
 type FunctionFormProps = {
   module: GenericModuleAbi;
@@ -38,14 +39,6 @@ export const WriteFunctionForm = ({ module, fn }: FunctionFormProps) => {
   );
   const { account } = useWallet();
   const network = useTargetNetwork();
-
-  // TODO: use network from useTargetNetwork
-  const state = { network_value: "" };
-  // if (network.targetNetwork.network === Network.CUSTOM) {
-  state.network_value = network.targetNetwork.fullnode ? network.targetNetwork.fullnode : "";
-  // } else {
-
-  // }
 
   const convertArgument = (arg: string | null | undefined, type: string): any => {
     if (typeof arg !== "string") {
@@ -156,9 +149,28 @@ export const WriteFunctionForm = ({ module, fn }: FunctionFormProps) => {
           <div className="flex-grow basis-0">
             {transactionResponse !== null && transactionResponse?.transactionSubmitted && (
               <div className="bg-base-300 rounded-3xl text-sm px-4 py-1.5 break-words overflow-auto">
-                <p className="font-bold m-0 mb-1">Result:</p>
                 <pre className="whitespace-pre-wrap break-words">
-                  {transactionResponse.success ? "✅ transaction successful. txreceipt: " : "❌ transaction failed"}
+                  <span className="font-bold">Result: </span>
+                  {transactionResponse.success ? (
+                    <>
+                      ✅ transaction successful
+                      {getBlockExplorerTxLink(network.targetNetwork, transactionResponse.transactionHash) && (
+                        <>
+                          <br />
+                          <a
+                            href={getBlockExplorerTxLink(network.targetNetwork, transactionResponse.transactionHash)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-primary hover:underline"
+                          >
+                            View on Explorer
+                          </a>
+                        </>
+                      )}
+                    </>
+                  ) : (
+                    "❌ transaction failed"
+                  )}
                 </pre>
               </div>
             )}
@@ -168,8 +180,6 @@ export const WriteFunctionForm = ({ module, fn }: FunctionFormProps) => {
                 <pre className="whitespace-pre-wrap break-words">{error}</pre>
               </div>
             )}
-            {/* TODO: Add TxReceipt for Move */}
-            {/* {displayedTxResult ? <TxReceipt txResult={displayedTxResult} /> : null} */}
           </div>
 
           <button

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -6,7 +6,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Bars3Icon, BugAntIcon } from "@heroicons/react/24/outline";
 import { CustomConnectButton } from "~~/components/scaffold-move";
-// import { FaucetButton } from "~~/components/scaffold-eth";
 import { useOutsideClick } from "~~/hooks/scaffold-move";
 
 type HeaderMenuLink = {

--- a/packages/nextjs/components/scaffold-move/CustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-move/CustomConnectButton/AddressInfoDropdown.tsx
@@ -3,9 +3,10 @@ import { NetworkOptions } from "./NetworkOptions";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import {
-  ArrowLeftOnRectangleIcon,
+  ArrowLeftEndOnRectangleIcon,
   ArrowTopRightOnSquareIcon,
   ArrowsRightLeftIcon,
+  BanknotesIcon,
   CheckCircleIcon,
   ChevronDownIcon,
   DocumentDuplicateIcon,
@@ -13,7 +14,8 @@ import {
 } from "@heroicons/react/24/outline";
 import { BlockieAvatar } from "~~/components/scaffold-move";
 import { useOutsideClick } from "~~/hooks/scaffold-move";
-import { getTargetNetworks } from "~~/utils/scaffold-move";
+import { useTargetNetwork } from "~~/hooks/scaffold-move/useTargetNetwork";
+import { getFaucetAddressLink, getTargetNetworks } from "~~/utils/scaffold-move";
 
 const allowedNetworks = getTargetNetworks();
 
@@ -33,6 +35,7 @@ export const AddressInfoDropdown = ({ address, blockExplorerAddressLink }: Addre
   useOutsideClick(dropdownRef, closeDropdown);
 
   const { disconnect, wallet } = useWallet();
+  const { targetNetwork } = useTargetNetwork();
 
   // Check if connected wallet is Petra or Pontem
   const isNetworkSwitchingDisabled = wallet?.name === "Petra" || wallet?.name === "Pontem";
@@ -79,7 +82,6 @@ export const AddressInfoDropdown = ({ address, blockExplorerAddressLink }: Addre
               </CopyToClipboard>
             )}
           </li>
-          {/* TODO: Add QR functionality */}
           <li className={selectingNetwork ? "hidden" : ""}>
             <label htmlFor="qrcode-modal" className="btn-sm !rounded-xl flex gap-3 py-3">
               <QrCodeIcon className="h-6 w-4 ml-2 sm:ml-0" />
@@ -118,12 +120,25 @@ export const AddressInfoDropdown = ({ address, blockExplorerAddressLink }: Addre
             </li>
           ) : null}
           <li className={selectingNetwork ? "hidden" : ""}>
+            <button className="btn-sm !rounded-xl flex gap-3 py-3" type="button">
+              <BanknotesIcon className="h-6 w-4 ml-2 sm:ml-0" />
+              <a
+                target="_blank"
+                href={getFaucetAddressLink(targetNetwork)}
+                rel="noopener noreferrer"
+                className="whitespace-nowrap"
+              >
+                Faucet
+              </a>
+            </button>
+          </li>
+          <li className={selectingNetwork ? "hidden" : ""}>
             <button
               className="menu-item text-error btn-sm !rounded-xl flex gap-3 py-3"
               type="button"
               onClick={() => disconnect()}
             >
-              <ArrowLeftOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
+              <ArrowLeftEndOnRectangleIcon className="h-6 w-4 ml-2 sm:ml-0" /> <span>Disconnect</span>
             </button>
           </li>
         </ul>

--- a/packages/nextjs/components/scaffold-move/CustomConnectButton/AddressQRCodeModal.tsx
+++ b/packages/nextjs/components/scaffold-move/CustomConnectButton/AddressQRCodeModal.tsx
@@ -21,7 +21,9 @@ export const AddressQRCodeModal = ({ address, modalId }: AddressQRCodeModalProps
             <div className="space-y-3 py-6">
               <div className="flex flex-col items-center gap-6">
                 <QRCodeSVG value={address} size={256} />
-                <Address address={address} format="long" disableAddressLink />
+                <div className="break-all">
+                  <Address address={address} format="long" disableAddressLink />
+                </div>
               </div>
             </div>
           </label>

--- a/packages/nextjs/components/scaffold-move/CustomConnectButton/WrongNetworkDropdown.tsx
+++ b/packages/nextjs/components/scaffold-move/CustomConnectButton/WrongNetworkDropdown.tsx
@@ -1,9 +1,8 @@
 import { NetworkOptions } from "./NetworkOptions";
-import { ArrowLeftEndOnRectangleIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { ArrowLeftEndOnRectangleIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 
 export const WrongNetworkDropdown = () => {
-
   const { disconnect } = useWallet();
 
   return (

--- a/packages/nextjs/components/scaffold-move/CustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-move/CustomConnectButton/index.tsx
@@ -4,8 +4,8 @@ import { Balance } from "../Balance";
 import { AddressInfoDropdown } from "./AddressInfoDropdown";
 import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { WalletSelector } from "./WalletSelector";
-import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { WrongNetworkDropdown } from "./WrongNetworkDropdown";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { useTargetNetwork } from "~~/hooks/scaffold-move/useTargetNetwork";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-move";
 
@@ -13,7 +13,6 @@ export const CustomConnectButton = () => {
   const { targetNetwork } = useTargetNetwork();
 
   const { account, connected, network } = useWallet();
-
 
   const blockExplorerAddressLink = account ? getBlockExplorerAddressLink(targetNetwork, account?.address) : undefined;
 

--- a/packages/nextjs/hooks/scaffold-move/useSubmitTransaction.ts
+++ b/packages/nextjs/hooks/scaffold-move/useSubmitTransaction.ts
@@ -30,7 +30,6 @@ const useSubmitTransaction = <TModuleName extends ModuleName>(moduleName: TModul
   const network = useTargetNetwork();
   const aptos = useAptosClient(network.targetNetwork.id);
 
-  // TODO: with Nightly wallet it can fail because network is mismatched.
   const { signAndSubmitTransaction } = useWallet();
 
   const moveModule = useGetModule(moduleName.toString());

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -9,7 +9,7 @@ export type ScaffoldConfig = {
 
 const scaffoldConfig = {
   // The networks on which your DApp is live
-  targetNetworks: [defaultChains.movement_bardock_testnet],
+  targetNetworks: [defaultChains.movement_testnet],
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect if you only target the local network (default is 4000)

--- a/packages/nextjs/utils/scaffold-move/chains.ts
+++ b/packages/nextjs/utils/scaffold-move/chains.ts
@@ -17,26 +17,15 @@ type Chains = {
 };
 
 export const defaultChains: Chains = {
-  movement_devnet: {
-    id: 4,
-    name: "Movement Devnet",
-    network: Network.CUSTOM,
-    fullnode: "https://aptos.devnet.m1.movementlabs.xyz",
-    indexer: "https://indexer.devnet.m1.movementlabs.xyz/",
-    faucet: "https://faucet2.movementlabs.xyz",
-    block_explorer: "https://explorer.devnet.m1.movementlabs.xyz",
-    explorer_network_param: "devnet",
-    native_token_symbol: "MOVE",
-  },
   movement_testnet: {
     id: 250,
     name: "Movement Bardock Testnet",
     network: Network.CUSTOM,
     fullnode: "https://aptos.testnet.bardock.movementlabs.xyz/v1",
     indexer: "",
-    faucet: "https://faucet.testnet.bardock.movementnetwork.xyz/",
+    faucet: "https://faucet.movementnetwork.xyz/?network=bardock",
     block_explorer: "https://explorer.movementnetwork.xyz",
-    explorer_network_param: "testnet",
+    explorer_network_param: "bardock+testnet",
     native_token_symbol: "MOVE",
   },
   movement_mainnet: {
@@ -58,11 +47,7 @@ export const defaultChains: Chains = {
     id: NetworkToChainId[Network.TESTNET],
     name: "Aptos Testnet",
     network: Network.TESTNET,
-  },
-  aptos_devnet: {
-    id: 149, // TODO: Hardcoded chainId for now, need to find a better solution
-    name: "Aptos Devnet",
-    network: Network.DEVNET,
+    faucet: "https://aptos.dev/en/network/faucet",
   },
   local: {
     id: NetworkToChainId[Network.LOCAL],

--- a/packages/nextjs/utils/scaffold-move/chains.ts
+++ b/packages/nextjs/utils/scaffold-move/chains.ts
@@ -28,29 +28,7 @@ export const defaultChains: Chains = {
     explorer_network_param: "devnet",
     native_token_symbol: "MOVE",
   },
-  movement_suzuka_testnet: {
-    id: 27,
-    name: "Movement Suzuka Testnet",
-    network: Network.CUSTOM,
-    fullnode: "https://aptos.testnet.suzuka.movementlabs.xyz/v1",
-    indexer: "https://indexer.testnet.m1.movementlabs.xyz/",
-    faucet: "https://faucet.testnet.suzuka.movementlabs.xyz/",
-    block_explorer: "https://explorer.movementnetwork.xyz",
-    explorer_network_param: "testnet",
-    native_token_symbol: "MOVE",
-  },
   movement_testnet: {
-    id: 177,
-    name: "Movement Porto Testnet",
-    network: Network.CUSTOM,
-    fullnode: "https://aptos.testnet.porto.movementlabs.xyz/v1",
-    indexer: "https://indexer.testnet.porto.movementnetwork.xyz/v1/graphql",
-    faucet: "https://mizu.testnet.porto.movementnetwork.xyz/",
-    block_explorer: "https://explorer.movementnetwork.xyz",
-    explorer_network_param: "testnet",
-    native_token_symbol: "MOVE",
-  },
-  movement_bardock_testnet: {
     id: 250,
     name: "Movement Bardock Testnet",
     network: Network.CUSTOM,
@@ -82,8 +60,7 @@ export const defaultChains: Chains = {
     network: Network.TESTNET,
   },
   aptos_devnet: {
-    // TODO: Hardcoded chainId for now, need to find a better solution
-    id: 149,
+    id: 149, // TODO: Hardcoded chainId for now, need to find a better solution
     name: "Aptos Devnet",
     network: Network.DEVNET,
   },

--- a/packages/nextjs/utils/scaffold-move/networks.ts
+++ b/packages/nextjs/utils/scaffold-move/networks.ts
@@ -3,6 +3,16 @@ import scaffoldConfig from "~~/scaffold.config";
 import { Chain } from "~~/utils/scaffold-move/chains";
 
 /**
+ * Gives the faucet address URL, returns empty string if the faucet is not defined (mainnet or local chain)
+ */
+export function getFaucetAddressLink(chain: Chain) {
+  if (chain.faucet === "") {
+    return "";
+  }
+  return chain.faucet;
+}
+
+/**
  * Gives the block explorer transaction URL, returns empty string if the network is a local chain
  */
 export function getBlockExplorerTxLink(chain: Chain, txnHash: string) {


### PR DESCRIPTION
## Description

- Removed `yarn publish`, since it duplicated `yarn deploy`
- Created deploy.js to wrap around `aptos move deploy`, deploy with `--move-1` and `--bytecode-version 6` tags for custom networks. 
- Add tx reciepts to debug tab
- Add faucet link in wallet dropdown